### PR TITLE
quote a word that you are referencing: be

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Comedy writers seek the funniest results, horror writers strive for the scariest
 
 To engage and educate readers, choose precise, strong, specific verbs; avoid imprecise, weak, or generic verbs. For example, try to reduce your use of the following generic verbs:
 
-*   forms of be: is, are, am, was, were, etc.
+*   forms of "be": is, are, am, was, were, etc.
 *   occur
 *   happen
 


### PR DESCRIPTION
In referencing the term *be* as an object instead of a word in the sentence, I suggest that you distinguish from the text around it by quoting it, or by putting in italics or bold.