### PR TITLE
Change *weekend programmer* to *inexperienced programmer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Specifying a subject (**clients**) creates a clearer experience for the reader:
 
 # Short sentences
 
-Software engineers generally aim to minimize the number of lines of code in an implementation. A great engineer can sometimes implement in 25 lines what it takes a weekend programmer to do in 100 lines. Great engineers minimize lines for the following reasons:
+Software engineers generally aim to minimize the number of lines of code in an implementation. A great engineer can sometimes implement in 25 lines what it takes an inexperienced programmer to do in 100 lines. Great engineers minimize lines for the following reasons:
 
 *   Shorter code typically runs faster than longer code.
 *   Shorter code is typically easier to maintain than longer code.


### PR DESCRIPTION
The trivialising of "weekend programmers" could be considered mildly offensive to open source developers, who often are weekend programmers. Actually, typically the day time programming is done according to work deadlines and forced compromises, but on the weekend they get to work on their pet project and get the chance to write perfect code.
So I suggest selecting a term which categorises the programmer's capability: E.g.: inexperienced, less capable, average, ...